### PR TITLE
Switched internal rotation to quaternion

### DIFF
--- a/aiv-fast3d-example/Program.cs
+++ b/aiv-fast3d-example/Program.cs
@@ -45,10 +45,6 @@ namespace Aiv.Fast3D.Example
 			Mesh3 stormTrooper = ObjLoader.Load("Assets/Stormtrooper.obj", new Vector3(50, -50, 50))[0];
 			stormTrooper.Position3 = new Vector3(200, 200, 100);
 
-            Vector3 suzanneEuler = new Vector3();
-            Vector3 mesh3Euler = new Vector3();
-            Vector3 trooperEuler = new Vector3();
-
 			Texture texture = new Texture("Assets/Stormtrooper.png");
 			texture.SetRepeatX();
 			texture.SetRepeatY();
@@ -120,6 +116,13 @@ namespace Aiv.Fast3D.Example
 
 			mesh3.Scale3 = new Vector3(0.5f, 0.5f, 0.5f);
 
+            float mesh3Pitch = 0f;
+            float mesh3Yaw = 0f;
+
+            float suzanneYaw = 0f;
+
+            float stormTrooperYaw = 0f;
+
 			while (window.opened)
 			{
 				if (window.GetKey(KeyCode.Esc))
@@ -127,19 +130,19 @@ namespace Aiv.Fast3D.Example
 
 				if (window.GetKey(KeyCode.Up))
 				{
-                    mesh3Euler += new Vector3(-20 * window.deltaTime, 0f, 0f);
-                    suzanneEuler += new Vector3(0f, -30 * window.deltaTime, 0f);
-                    trooperEuler += new Vector3(0f, 30 * window.deltaTime, 0f);
-                }
+                    mesh3Pitch      += -20 * window.deltaTime;
+                    suzanneYaw      += -30 * window.deltaTime;
+                    stormTrooperYaw +=  30 * window.deltaTime;
+				}
 
 				mesh3.Position3 = new Vector3(130, 130, 100);
 				mesh3.Scale3    = new Vector3(0.5f, 0.5f, 0.5f);
 
-                mesh3Euler += new Vector3(0f, 0f, -10 * window.deltaTime);
+                mesh3Yaw        += -10 * window.deltaTime;
 
-                mesh3.EulerRotation3 = mesh3Euler;
-                suzanne.EulerRotation3 = suzanneEuler;
-                stormTrooper.EulerRotation3 = trooperEuler;
+				mesh3.SetEulerRotation(mesh3Pitch, mesh3Yaw, 0f);
+				suzanne.SetEulerRotation(0f, suzanneYaw, 0f);
+				stormTrooper.SetEulerRotation(0f, stormTrooperYaw, 0f);
 
 				background.DrawTexture(backgroundTexture);
 

--- a/aiv-fast3d-example/Program.cs
+++ b/aiv-fast3d-example/Program.cs
@@ -45,6 +45,10 @@ namespace Aiv.Fast3D.Example
 			Mesh3 stormTrooper = ObjLoader.Load("Assets/Stormtrooper.obj", new Vector3(50, -50, 50))[0];
 			stormTrooper.Position3 = new Vector3(200, 200, 100);
 
+            Vector3 suzanneEuler = new Vector3();
+            Vector3 mesh3Euler = new Vector3();
+            Vector3 trooperEuler = new Vector3();
+
 			Texture texture = new Texture("Assets/Stormtrooper.png");
 			texture.SetRepeatX();
 			texture.SetRepeatY();
@@ -116,13 +120,6 @@ namespace Aiv.Fast3D.Example
 
 			mesh3.Scale3 = new Vector3(0.5f, 0.5f, 0.5f);
 
-            float mesh3Pitch = 0f;
-            float mesh3Yaw = 0f;
-
-            float suzanneYaw = 0f;
-
-            float stormTrooperYaw = 0f;
-
 			while (window.opened)
 			{
 				if (window.GetKey(KeyCode.Esc))
@@ -130,19 +127,19 @@ namespace Aiv.Fast3D.Example
 
 				if (window.GetKey(KeyCode.Up))
 				{
-                    mesh3Pitch      += -20 * window.deltaTime;
-                    suzanneYaw      += -30 * window.deltaTime;
-                    stormTrooperYaw +=  30 * window.deltaTime;
-				}
+                    mesh3Euler += new Vector3(-20 * window.deltaTime, 0f, 0f);
+                    suzanneEuler += new Vector3(0f, -30 * window.deltaTime, 0f);
+                    trooperEuler += new Vector3(0f, 30 * window.deltaTime, 0f);
+                }
 
 				mesh3.Position3 = new Vector3(130, 130, 100);
 				mesh3.Scale3    = new Vector3(0.5f, 0.5f, 0.5f);
 
-                mesh3Yaw        += -10 * window.deltaTime;
+                mesh3Euler += new Vector3(0f, 0f, -10 * window.deltaTime);
 
-				mesh3.SetEulerRotation(mesh3Pitch, mesh3Yaw, 0f);
-				suzanne.SetEulerRotation(0f, suzanneYaw, 0f);
-				stormTrooper.SetEulerRotation(0f, stormTrooperYaw, 0f);
+                mesh3.EulerRotation3 = mesh3Euler;
+                suzanne.EulerRotation3 = suzanneEuler;
+                stormTrooper.EulerRotation3 = trooperEuler;
 
 				background.DrawTexture(backgroundTexture);
 

--- a/aiv-fast3d-example/Program.cs
+++ b/aiv-fast3d-example/Program.cs
@@ -116,6 +116,12 @@ namespace Aiv.Fast3D.Example
 
 			mesh3.Scale3 = new Vector3(0.5f, 0.5f, 0.5f);
 
+            float mesh3Pitch = 0f;
+            float mesh3Yaw = 0f;
+
+            float suzanneYaw = 0f;
+
+            float stormTrooperYaw = 0f;
 
 			while (window.opened)
 			{
@@ -124,14 +130,19 @@ namespace Aiv.Fast3D.Example
 
 				if (window.GetKey(KeyCode.Up))
 				{
-					mesh3.EulerRotation3 += new Vector3(-20 * window.deltaTime, 0, 0);
-					suzanne.EulerRotation3 += new Vector3(0, -30 * window.deltaTime, 0);
-					stormTrooper.EulerRotation3 += new Vector3(0, 30 * window.deltaTime, 0);
+                    mesh3Pitch      += -20 * window.deltaTime;
+                    suzanneYaw      += -30 * window.deltaTime;
+                    stormTrooperYaw +=  30 * window.deltaTime;
 				}
 
 				mesh3.Position3 = new Vector3(130, 130, 100);
-				mesh3.Scale3 = new Vector3(0.5f, 0.5f, 0.5f);
-				mesh3.EulerRotation3 += new Vector3(0, -10 * window.deltaTime, 0);
+				mesh3.Scale3    = new Vector3(0.5f, 0.5f, 0.5f);
+
+                mesh3Yaw        += -10 * window.deltaTime;
+
+				mesh3.SetEulerRotation(mesh3Pitch, mesh3Yaw, 0f);
+				suzanne.SetEulerRotation(0f, suzanneYaw, 0f);
+				stormTrooper.SetEulerRotation(0f, stormTrooperYaw, 0f);
 
 				background.DrawTexture(backgroundTexture);
 

--- a/aiv-fast3d-perspective-example/Program.cs
+++ b/aiv-fast3d-perspective-example/Program.cs
@@ -53,7 +53,8 @@ namespace Aiv.Fast3D.Perspective.Example
 
             window.SetCursor(false);
 
-            PerspectiveCamera camera = new PerspectiveCamera(new Vector3(0, 6, 30), new Vector3(-10, 180, 0), 60, 0.01f, 1000);
+            Vector3 cameraEuler = new Vector3(-10, 180, 0);
+            PerspectiveCamera camera = new PerspectiveCamera(new Vector3(0, 6, 30), cameraEuler, 60, 0.01f, 1000);
 
             Texture crate = new Texture("Assets/crate.jpg");
 
@@ -121,6 +122,7 @@ namespace Aiv.Fast3D.Perspective.Example
 
             Mesh3 movingTrooper = ObjLoader.Load("Assets/Stormtrooper.obj", Vector3.One)[0];
             movingTrooper.Position3 = new Vector3(0, 0, 2);
+            Vector3 movingTrooperRotation = new Vector3();
 
             foreach (SkeletalAnimation animation in animations)
             {
@@ -163,10 +165,12 @@ namespace Aiv.Fast3D.Perspective.Example
             PostProcessingEffect fxaa = window.AddPostProcessingEffect(new FXAA());
 
             Plane plane = new Plane();
+            Vector3 planeEuler = new Vector3();
 
             Vector3 shadowOffset = new Vector3(0, 0, 0.22f);
 
             Sphere sphere = new Sphere();
+            Vector3 sphereEuler = new Vector3();
             Texture world = new Texture("Assets/world.jpg");
 
             while (window.IsOpened)
@@ -202,17 +206,18 @@ namespace Aiv.Fast3D.Perspective.Example
                 }
 
                 if (window.GetKey(KeyCode.Right))
-                    camera.EulerRotation3 += new Vector3(0, 90 + 45, 0) * window.deltaTime;
+                    cameraEuler += new Vector3(0, 90 + 45, 0) * window.deltaTime;
 
                 if (window.GetKey(KeyCode.Left))
-                    camera.EulerRotation3 -= new Vector3(0, 90 + 45, 0) * window.deltaTime;
+                    cameraEuler -= new Vector3(0, 90 + 45, 0) * window.deltaTime;
 
                 if (window.GetKey(KeyCode.P))
-                    camera.EulerRotation3 += new Vector3(90 + 45, 0, 0) * window.deltaTime;
+                    cameraEuler += new Vector3(90 + 45, 0, 0) * window.deltaTime;
 
                 if (window.GetKey(KeyCode.L))
-                    camera.EulerRotation3 -= new Vector3(90 + 45, 0, 0) * window.deltaTime;
+                    cameraEuler -= new Vector3(90 + 45, 0, 0) * window.deltaTime;
 
+                camera.SetEulerRotation(cameraEuler);
 
                 //fxaa.enabled = window.GetKey(KeyCode.X);
 
@@ -307,12 +312,12 @@ namespace Aiv.Fast3D.Perspective.Example
                 window.CullFrontFaces();
                 floor.DrawShadowMap(directionalLight);
                 pyramid.Scale3 = new Vector3(1, 2, 1);
-                pyramid.EulerRotation3 = pyramidRotation;
+                pyramid.SetEulerRotation(pyramidRotation);
                 pyramid.Position3 = new Vector3(-6, 2, 10) + shadowOffset;
                 pyramid.DrawShadowMap(directionalLight);
 
                 pyramid.Scale3 = new Vector3(1, 2, 1);
-                pyramid.Rotation3 = Vector3.Zero;
+                pyramid.SetRotation(Vector3.Zero);
                 pyramid.Position3 = new Vector3(-30, 2, 10) + shadowOffset;
                 pyramid.DrawShadowMap(directionalLight);
 
@@ -323,18 +328,18 @@ namespace Aiv.Fast3D.Perspective.Example
                 botMesh[1].DrawShadowMap(directionalLight);
 
                 stormTrooper.Position3 = new Vector3(0, 0, 5) + shadowOffset;
-                stormTrooper.Rotation3 = Vector3.Zero;
+                stormTrooper.SetRotation(Vector3.Zero);
                 stormTrooper.DrawShadowMap(directionalLight);
                 stormTrooper.Position3 = new Vector3(-5, 0, 5) + shadowOffset;
-                stormTrooper.Rotation3 = Vector3.Zero;
+                stormTrooper.SetRotation(Vector3.Zero);
                 stormTrooper.DrawShadowMap(directionalLight);
                 stormTrooper.Position3 = new Vector3(7, 0, 5) + shadowOffset;
-                stormTrooper.Rotation3 = Utils.LookAt((camera.Position3 - stormTrooper.Position3).Normalized());
+                stormTrooper.SetRotation(Utils.LookAt((camera.Position3 - stormTrooper.Position3).Normalized()));
                 stormTrooper.DrawShadowMap(directionalLight);
-                cube.EulerRotation3 = new Vector3(0, crateRotation, 0);
+                cube.SetEulerRotation(new Vector3(0, crateRotation, 0));
                 cube.Position3 = new Vector3(0, 7, 0) + shadowOffset;
                 cube.DrawShadowMap(directionalLight);
-                cube.EulerRotation3 = Vector3.Zero;
+                cube.SetEulerRotation(Vector3.Zero);
                 cube.Position3 = new Vector3(5, 1, 5) + shadowOffset;
                 cube.DrawShadowMap(directionalLight);
 
@@ -354,12 +359,12 @@ namespace Aiv.Fast3D.Perspective.Example
                 floor.DrawPhong(floorTexture, directionalLight, new Vector3(0.5f, 0.5f, 0.5f), 0, shadowTexture);
 
                 pyramid.Scale3 = new Vector3(1, 2, 1);
-                pyramid.EulerRotation3 = pyramidRotation;
+                pyramid.SetEulerRotation(pyramidRotation);
                 pyramid.Position3 = new Vector3(-6, 2, 10);
                 pyramid.DrawGouraud(new Vector4(1, 0, 0, 1), directionalLight, shadowTexture);
 
                 pyramid.Scale3 = new Vector3(1, 2, 1);
-                pyramid.EulerRotation3 = Vector3.Zero;
+                pyramid.SetEulerRotation(Vector3.Zero);
                 pyramid.Position3 = new Vector3(-30, 2, 10);
                 pyramid.DrawGouraud(new Vector4(1, 1, 0, 1), directionalLight, shadowTexture);
 
@@ -369,20 +374,20 @@ namespace Aiv.Fast3D.Perspective.Example
                 botMesh[1].DrawGouraud(new Vector4(1, 0, 0, 1), directionalLight, shadowTexture, 0.01f);
 
                 stormTrooper.Position3 = new Vector3(0, 0, 5);
-                stormTrooper.Rotation3 = Vector3.Zero;
+                stormTrooper.SetRotation(Vector3.Zero);
                 stormTrooper.DrawGouraud(stormTrooperTexture, directionalLight, shadowTexture);
 
                 stormTrooper.Position3 = new Vector3(-5, 0, 5);
-                stormTrooper.Rotation3 = Vector3.Zero;
+                stormTrooper.SetRotation(Vector3.Zero);
                 stormTrooper.DrawPhong(stormTrooperTexture, directionalLight, new Vector3(0, 0.1f, 0), 0.75f, shadowTexture);
 
                 stormTrooper.Position3 = new Vector3(7, 0, 5);
-                stormTrooper.Rotation3 = Utils.LookAt((camera.Position3 - stormTrooper.Position3).Normalized());
+                stormTrooper.SetRotation(Utils.LookAt((camera.Position3 - stormTrooper.Position3).Normalized()));
                 stormTrooper.DrawCel(stormTrooperTexture, directionalLight, new Vector3(0, 0.1f, 0), 0.75f, shadowTexture);
 
 
                 //cube.DrawColor(new Vector4(1, 0, 0, 1));
-                cube.EulerRotation3 = new Vector3(0, crateRotation, 0);
+                cube.SetEulerRotation(new Vector3(0, crateRotation, 0));
                 cube.Position3 = new Vector3(0, 7, 0);
                 cube.DrawTexture(crate);
 
@@ -390,14 +395,15 @@ namespace Aiv.Fast3D.Perspective.Example
                     movingTrooper.Position3 += movingTrooper.Forward * window.deltaTime * 2;
 
                 if (window.GetKey(KeyCode.G))
-                    movingTrooper.EulerRotation3 += new Vector3(0, 90, 0) * window.deltaTime;
+                    movingTrooperRotation += new Vector3(0, 90, 0) * window.deltaTime;
 
                 if (window.GetKey(KeyCode.H))
-                    movingTrooper.EulerRotation3 -= new Vector3(0, 90, 0) * window.deltaTime;
+                    movingTrooperRotation -= new Vector3(0, 90, 0) * window.deltaTime;
+                movingTrooper.SetEulerRotation(movingTrooperRotation);
 
                 movingTrooper.DrawGouraud(new Vector4(1, 0, 0, 1), directionalLight);
 
-                cube.EulerRotation3 = Vector3.Zero;
+                cube.SetEulerRotation(Vector3.Zero);
                 cube.Position3 = new Vector3(5, 1, 5);
                 cube.DrawGouraud(new Vector4(0, 0, 1, 1), directionalLight, shadowTexture);
 
@@ -410,11 +416,12 @@ namespace Aiv.Fast3D.Perspective.Example
                 }
 
                 plane.Position3 = new Vector3(-13, 5, 0);
-                plane.EulerRotation3 += Vector3.UnitY * 30 * window.deltaTime;
+                planeEuler += Vector3.UnitY * 30 * window.deltaTime;
                 plane.DrawColor(new Vector4(1, 1, 0, 1));
 
                 sphere.Position3 = new Vector3(-5, 2, 20);
-                sphere.EulerRotation3 += Vector3.UnitY * 10 * window.deltaTime;
+                sphereEuler += Vector3.UnitY * 10 * window.deltaTime;
+                sphere.SetEulerRotation(sphereEuler);
                 sphere.Scale3 = new Vector3(3);
                 sphere.DrawPhong(world, directionalLight, new Vector3(0.2f, 0.2f, 0.2f));
                 //sphere.DrawColor(new Vector4(1, 0, 0, 1));
@@ -427,7 +434,8 @@ namespace Aiv.Fast3D.Perspective.Example
                 window.DisableCullFaces();
 
                 plane.Position3 = new Vector3(-10, 5, 0);
-                plane.EulerRotation3 += Vector3.UnitY * 30 * window.deltaTime;
+                planeEuler += Vector3.UnitY * 30 * window.deltaTime;
+                plane.SetEulerRotation(planeEuler);
                 plane.DrawColor(new Vector4(0, 1, 1, 1));
 
                 window.Update();

--- a/aiv-fast3d/Mesh3.cs
+++ b/aiv-fast3d/Mesh3.cs
@@ -267,23 +267,7 @@ void main(){
             }
 		}
 
-        public Vector3 Rotation3
-        {
-            set
-            {
-                internalRotation = (Matrix3.CreateRotationX(value.X) * Matrix3.CreateRotationZ(value.Z) * Matrix3.CreateRotationY(value.Y)).ExtractRotation();
-            }
-        }
-
-        public Vector3 EulerRotation3
-        {
-            set
-            {
-                Rotation3 = value * (float)Math.PI / 180f;
-            }
-        }
-
-        private Vector3 position3;
+		private Vector3 position3;
 		public Vector3 Position3
 		{
 			get

--- a/aiv-fast3d/Mesh3.cs
+++ b/aiv-fast3d/Mesh3.cs
@@ -254,18 +254,17 @@ void main(){
 
 		private static Shader simpleShader3 = new Shader(simpleVertexShader3, simpleFragmentShader3, null, null, null);
 
-		private Vector3 internalRotation;
-
-		public Vector3 Rotation3
+		private Quaternion internalRotation;
+		public Quaternion Quaternion
 		{
 			get
 			{
-				return internalRotation;
+                return internalRotation;
 			}
-			set
-			{
-				internalRotation = value;
-			}
+            set
+            {
+                internalRotation = value;
+            }
 		}
 
 		private Vector3 position3;
@@ -304,27 +303,6 @@ void main(){
 			set
 			{
 				pivot3 = value;
-			}
-		}
-
-		public Quaternion Quaternion
-		{
-			get
-			{
-				return (Matrix3.CreateRotationY(internalRotation.Y) * Matrix3.CreateRotationZ(internalRotation.Z) * Matrix3.CreateRotationX(internalRotation.X)).ExtractRotation();
-
-			}
-		}
-
-		public Vector3 EulerRotation3
-		{
-			get
-			{
-				return this.Rotation3 * 180f / (float)Math.PI;
-			}
-			set
-			{
-				this.Rotation3 = value * (float)Math.PI / 180f;
 			}
 		}
 
@@ -507,7 +485,7 @@ void main(){
 
 			scale3 = Vector3.One;
 			position3 = Vector3.Zero;
-			internalRotation = Vector3.Zero;
+			internalRotation = Quaternion.Identity;
 
 			this.vnBufferId = Graphics.NewBuffer();
 			Graphics.MapBufferToArray(this.vnBufferId, 3, 3);
@@ -551,7 +529,31 @@ void main(){
 			};
 		}
 
-		public void UpdateNormals()
+        public void SetEulerRotation(Vector3 pitchYawRoll)
+        {
+
+            float degToRad = (float)Math.PI / 180f;
+            pitchYawRoll *= degToRad;
+            internalRotation = (Matrix3.CreateRotationX(pitchYawRoll.X) * Matrix3.CreateRotationZ(pitchYawRoll.Z) * Matrix3.CreateRotationY(pitchYawRoll.Y)).ExtractRotation();
+        }
+
+        public void SetEulerRotation(float pitch, float yaw, float roll)
+        {
+            float degToRad = (float)Math.PI / 180f;
+            internalRotation = (Matrix3.CreateRotationX(pitch * degToRad) * Matrix3.CreateRotationZ(roll * degToRad) * Matrix3.CreateRotationY(yaw * degToRad)).ExtractRotation();
+        }
+
+        public void SetRotation(Vector3 pitchYawRoll)
+        {
+            internalRotation = (Matrix3.CreateRotationX(pitchYawRoll.X) * Matrix3.CreateRotationZ(pitchYawRoll.Z) * Matrix3.CreateRotationY(pitchYawRoll.Y)).ExtractRotation();
+        }
+
+        public void SetRotation(float pitch, float yaw, float roll)
+        {
+            internalRotation = (Matrix3.CreateRotationX(pitch) * Matrix3.CreateRotationZ(roll) * Matrix3.CreateRotationY(yaw)).ExtractRotation();
+        }
+
+        public void UpdateNormals()
 		{
 			if (this.vn == null)
 				return;
@@ -590,7 +592,7 @@ void main(){
 #else
                 Matrix4.Scale(this.scale3.X, this.scale3.Y, this.scale3.Z) *
 #endif
-				Matrix4.CreateRotationY(internalRotation.Y) * Matrix4.CreateRotationZ(internalRotation.Z) * Matrix4.CreateRotationX(internalRotation.X) *
+				Matrix4.CreateFromQuaternion(Quaternion) *
 				// here we do not re-add the pivot, so translation is pivot based too
 				Matrix4.CreateTranslation(this.position3.X, this.position3.Y, this.position3.Z);
 

--- a/aiv-fast3d/Mesh3.cs
+++ b/aiv-fast3d/Mesh3.cs
@@ -267,7 +267,23 @@ void main(){
             }
 		}
 
-		private Vector3 position3;
+        public Vector3 Rotation3
+        {
+            set
+            {
+                internalRotation = (Matrix3.CreateRotationX(value.X) * Matrix3.CreateRotationZ(value.Z) * Matrix3.CreateRotationY(value.Y)).ExtractRotation();
+            }
+        }
+
+        public Vector3 EulerRotation3
+        {
+            set
+            {
+                Rotation3 = value * (float)Math.PI / 180f;
+            }
+        }
+
+        private Vector3 position3;
 		public Vector3 Position3
 		{
 			get

--- a/aiv-fast3d/PerspectiveCamera.cs
+++ b/aiv-fast3d/PerspectiveCamera.cs
@@ -49,6 +49,31 @@ namespace Aiv.Fast3D
 		}
 
 		private Quaternion internalRotation;
+
+        public void SetEulerRotation(Vector3 pitchYawRoll)
+        {
+            float degToRad = (float)Math.PI / 180f;
+            pitchYawRoll *= degToRad;
+            internalRotation = (Matrix3.CreateRotationX(pitchYawRoll.X) * Matrix3.CreateRotationZ(pitchYawRoll.Z) * Matrix3.CreateRotationY(pitchYawRoll.Y)).ExtractRotation();
+        }
+
+        public void SetEulerRotation(float pitch, float yaw, float roll)
+        {
+            float degToRad = (float)Math.PI / 180f;
+            internalRotation = (Matrix3.CreateRotationX(pitch * degToRad) * Matrix3.CreateRotationZ(roll * degToRad) * Matrix3.CreateRotationY(yaw * degToRad)).ExtractRotation();
+        }
+
+        public void SetRotation(Vector3 pitchYawRoll)
+        {
+            internalRotation = (Matrix3.CreateRotationX(pitchYawRoll.X) * Matrix3.CreateRotationZ(pitchYawRoll.Z) * Matrix3.CreateRotationY(pitchYawRoll.Y)).ExtractRotation();
+        }
+
+        public void SetRotation(float pitch, float yaw, float roll)
+        {
+            internalRotation = (Matrix3.CreateRotationX(pitch) * Matrix3.CreateRotationZ(roll) * Matrix3.CreateRotationY(yaw)).ExtractRotation();
+        }
+
+
         public Quaternion Quaternion
 		{
 			get
@@ -61,23 +86,7 @@ namespace Aiv.Fast3D
             }
 		}
 
-        public Vector3 Rotation3
-        {
-            set
-            {
-                internalRotation = (Matrix3.CreateRotationX(value.X) * Matrix3.CreateRotationZ(value.Z) * Matrix3.CreateRotationY(value.Y)).ExtractRotation();
-            }
-        }
-
-        public Vector3 EulerRotation3
-        {
-            set
-            {
-                Rotation3 = value * (float)Math.PI / 180f;
-            }
-        }
-
-        private float fov;
+		private float fov;
 		private float zNear;
 		private float zFar;
 		private float aspectRatio;
@@ -115,28 +124,5 @@ namespace Aiv.Fast3D
 			float fovY = fov / aspectRatio;
 			return Matrix4.CreatePerspectiveFieldOfView(fovY, aspectRatio, zNear, zFar);
 		}
-
-        public void SetEulerRotation(Vector3 pitchYawRoll)
-        {
-            float degToRad = (float)Math.PI / 180f;
-            pitchYawRoll *= degToRad;
-            internalRotation = (Matrix3.CreateRotationX(pitchYawRoll.X) * Matrix3.CreateRotationZ(pitchYawRoll.Z) * Matrix3.CreateRotationY(pitchYawRoll.Y)).ExtractRotation();
-        }
-
-        public void SetEulerRotation(float pitch, float yaw, float roll)
-        {
-            float degToRad = (float)Math.PI / 180f;
-            internalRotation = (Matrix3.CreateRotationX(pitch * degToRad) * Matrix3.CreateRotationZ(roll * degToRad) * Matrix3.CreateRotationY(yaw * degToRad)).ExtractRotation();
-        }
-
-        public void SetRotation(Vector3 pitchYawRoll)
-        {
-            internalRotation = (Matrix3.CreateRotationX(pitchYawRoll.X) * Matrix3.CreateRotationZ(pitchYawRoll.Z) * Matrix3.CreateRotationY(pitchYawRoll.Y)).ExtractRotation();
-        }
-
-        public void SetRotation(float pitch, float yaw, float roll)
-        {
-            internalRotation = (Matrix3.CreateRotationX(pitch) * Matrix3.CreateRotationZ(roll) * Matrix3.CreateRotationY(yaw)).ExtractRotation();
-        }
 	}
 }

--- a/aiv-fast3d/PerspectiveCamera.cs
+++ b/aiv-fast3d/PerspectiveCamera.cs
@@ -49,31 +49,6 @@ namespace Aiv.Fast3D
 		}
 
 		private Quaternion internalRotation;
-
-        public void SetEulerRotation(Vector3 pitchYawRoll)
-        {
-            float degToRad = (float)Math.PI / 180f;
-            pitchYawRoll *= degToRad;
-            internalRotation = (Matrix3.CreateRotationX(pitchYawRoll.X) * Matrix3.CreateRotationZ(pitchYawRoll.Z) * Matrix3.CreateRotationY(pitchYawRoll.Y)).ExtractRotation();
-        }
-
-        public void SetEulerRotation(float pitch, float yaw, float roll)
-        {
-            float degToRad = (float)Math.PI / 180f;
-            internalRotation = (Matrix3.CreateRotationX(pitch * degToRad) * Matrix3.CreateRotationZ(roll * degToRad) * Matrix3.CreateRotationY(yaw * degToRad)).ExtractRotation();
-        }
-
-        public void SetRotation(Vector3 pitchYawRoll)
-        {
-            internalRotation = (Matrix3.CreateRotationX(pitchYawRoll.X) * Matrix3.CreateRotationZ(pitchYawRoll.Z) * Matrix3.CreateRotationY(pitchYawRoll.Y)).ExtractRotation();
-        }
-
-        public void SetRotation(float pitch, float yaw, float roll)
-        {
-            internalRotation = (Matrix3.CreateRotationX(pitch) * Matrix3.CreateRotationZ(roll) * Matrix3.CreateRotationY(yaw)).ExtractRotation();
-        }
-
-
         public Quaternion Quaternion
 		{
 			get
@@ -86,7 +61,23 @@ namespace Aiv.Fast3D
             }
 		}
 
-		private float fov;
+        public Vector3 Rotation3
+        {
+            set
+            {
+                internalRotation = (Matrix3.CreateRotationX(value.X) * Matrix3.CreateRotationZ(value.Z) * Matrix3.CreateRotationY(value.Y)).ExtractRotation();
+            }
+        }
+
+        public Vector3 EulerRotation3
+        {
+            set
+            {
+                Rotation3 = value * (float)Math.PI / 180f;
+            }
+        }
+
+        private float fov;
 		private float zNear;
 		private float zFar;
 		private float aspectRatio;
@@ -124,5 +115,28 @@ namespace Aiv.Fast3D
 			float fovY = fov / aspectRatio;
 			return Matrix4.CreatePerspectiveFieldOfView(fovY, aspectRatio, zNear, zFar);
 		}
+
+        public void SetEulerRotation(Vector3 pitchYawRoll)
+        {
+            float degToRad = (float)Math.PI / 180f;
+            pitchYawRoll *= degToRad;
+            internalRotation = (Matrix3.CreateRotationX(pitchYawRoll.X) * Matrix3.CreateRotationZ(pitchYawRoll.Z) * Matrix3.CreateRotationY(pitchYawRoll.Y)).ExtractRotation();
+        }
+
+        public void SetEulerRotation(float pitch, float yaw, float roll)
+        {
+            float degToRad = (float)Math.PI / 180f;
+            internalRotation = (Matrix3.CreateRotationX(pitch * degToRad) * Matrix3.CreateRotationZ(roll * degToRad) * Matrix3.CreateRotationY(yaw * degToRad)).ExtractRotation();
+        }
+
+        public void SetRotation(Vector3 pitchYawRoll)
+        {
+            internalRotation = (Matrix3.CreateRotationX(pitchYawRoll.X) * Matrix3.CreateRotationZ(pitchYawRoll.Z) * Matrix3.CreateRotationY(pitchYawRoll.Y)).ExtractRotation();
+        }
+
+        public void SetRotation(float pitch, float yaw, float roll)
+        {
+            internalRotation = (Matrix3.CreateRotationX(pitch) * Matrix3.CreateRotationZ(roll) * Matrix3.CreateRotationY(yaw)).ExtractRotation();
+        }
 	}
 }

--- a/aiv-fast3d/PerspectiveCamera.cs
+++ b/aiv-fast3d/PerspectiveCamera.cs
@@ -28,7 +28,7 @@ namespace Aiv.Fast3D
 		{
 			get
 			{
-				return (Matrix3.CreateRotationY(internalRotation.Y) * Matrix3.CreateRotationZ(internalRotation.Z) * Matrix3.CreateRotationX(internalRotation.X)) * Vector3.UnitZ;
+				return Quaternion * Vector3.UnitZ;
 			}
 		}
 
@@ -44,42 +44,46 @@ namespace Aiv.Fast3D
 		{
 			get
 			{
-				return (Matrix3.CreateRotationY(internalRotation.Y) * Matrix3.CreateRotationZ(internalRotation.Z) * Matrix3.CreateRotationX(internalRotation.X)) * Vector3.UnitY;
+				return Quaternion * Vector3.UnitY;
 			}
 		}
 
-		private Vector3 internalRotation;
+		private Quaternion internalRotation;
 
-		public Vector3 EulerRotation3
+        public void SetEulerRotation(Vector3 pitchYawRoll)
+        {
+            float degToRad = (float)Math.PI / 180f;
+            pitchYawRoll *= degToRad;
+            internalRotation = (Matrix3.CreateRotationX(pitchYawRoll.X) * Matrix3.CreateRotationZ(pitchYawRoll.Z) * Matrix3.CreateRotationY(pitchYawRoll.Y)).ExtractRotation();
+        }
+
+        public void SetEulerRotation(float pitch, float yaw, float roll)
+        {
+            float degToRad = (float)Math.PI / 180f;
+            internalRotation = (Matrix3.CreateRotationX(pitch * degToRad) * Matrix3.CreateRotationZ(roll * degToRad) * Matrix3.CreateRotationY(yaw * degToRad)).ExtractRotation();
+        }
+
+        public void SetRotation(Vector3 pitchYawRoll)
+        {
+            internalRotation = (Matrix3.CreateRotationX(pitchYawRoll.X) * Matrix3.CreateRotationZ(pitchYawRoll.Z) * Matrix3.CreateRotationY(pitchYawRoll.Y)).ExtractRotation();
+        }
+
+        public void SetRotation(float pitch, float yaw, float roll)
+        {
+            internalRotation = (Matrix3.CreateRotationX(pitch) * Matrix3.CreateRotationZ(roll) * Matrix3.CreateRotationY(yaw)).ExtractRotation();
+        }
+
+
+        public Quaternion Quaternion
 		{
 			get
 			{
-				return Rotation3 * (float)(180f / Math.PI);
+                return internalRotation;
 			}
-			set
-			{
-				Rotation3 = value * (float)(Math.PI / 180f);
-			}
-		}
-
-		public Vector3 Rotation3
-		{
-			get
-			{
-				return internalRotation;
-			}
-			set
-			{
-				internalRotation = value;
-			}
-		}
-
-		public Quaternion Quaternion
-		{
-			get
-			{
-				return (Matrix3.CreateRotationY(internalRotation.Y) * Matrix3.CreateRotationZ(internalRotation.Z) * Matrix3.CreateRotationX(internalRotation.X)).ExtractRotation();
-			}
+            set
+            {
+                internalRotation = value;
+            }
 		}
 
 		private float fov;
@@ -98,7 +102,7 @@ namespace Aiv.Fast3D
 		public PerspectiveCamera(Vector3 position, Vector3 eulerRotation, float fov, float zNear, float zFar, float aspectRatio = 0)
 		{
 			this.position3 = position;
-			this.internalRotation = eulerRotation * (float)(Math.PI / 180f);
+            this.SetEulerRotation(eulerRotation);
 			this.fov = fov * (float)(Math.PI / 180f);
 			this.zNear = zNear;
 			this.zFar = zFar;

--- a/aiv-fast3d/Utils.cs
+++ b/aiv-fast3d/Utils.cs
@@ -33,5 +33,39 @@ namespace Aiv.Fast3D
 		{
 			return LookAt(direction, Vector3.UnitY);
 		}
-	}
+
+
+        // from http://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToEuler/index.htm
+        public static Vector3 QuaternionToPitchYawRoll(Quaternion q)
+        {
+            float yaw, pitch, roll;
+            float test = q.X * q.Y + q.Z * q.W;
+
+            // 90 deg roll singularity
+            if (test > 0.499f)
+            {
+                yaw   = 2f * (float)Math.Atan2(q.X, q.W);
+                roll  = MathHelper.PiOver2;
+                pitch = 0f;
+            }
+            // -90 deg roll singularity
+            if (test < -0.499f)
+            {
+                yaw   = -2f * (float)Math.Atan2(q.X, q.W);
+                roll  = -MathHelper.PiOver2;
+                pitch = 0f;
+            }
+            else
+            {
+                float sqx = q.X * q.X;
+                float sqy = q.Y * q.Y;
+                float sqz = q.Z * q.Z;
+                yaw   = (float)Math.Atan2(2 * q.Y * q.W - 2 * q.X * q.Z, 1 - 2 * sqy - 2 * sqz);
+                roll  = (float)Math.Asin(2 * test);
+                pitch = (float)Math.Atan2(2 * q.X * q.W - 2 * q.Y * q.Z, 1 - 2 * sqx - 2 * sqz);
+            }
+
+            return new Vector3(pitch, yaw, roll);
+        }
+    }
 }

--- a/aiv-fast3d/Utils.cs
+++ b/aiv-fast3d/Utils.cs
@@ -33,39 +33,5 @@ namespace Aiv.Fast3D
 		{
 			return LookAt(direction, Vector3.UnitY);
 		}
-
-
-        // from http://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToEuler/index.htm
-        public static Vector3 QuaternionToPitchYawRoll(Quaternion q)
-        {
-            float yaw, pitch, roll;
-            float test = q.X * q.Y + q.Z * q.W;
-
-            // 90 deg roll singularity
-            if (test > 0.499f)
-            {
-                yaw   = 2f * (float)Math.Atan2(q.X, q.W);
-                roll  = MathHelper.PiOver2;
-                pitch = 0f;
-            }
-            // -90 deg roll singularity
-            if (test < -0.499f)
-            {
-                yaw   = -2f * (float)Math.Atan2(q.X, q.W);
-                roll  = -MathHelper.PiOver2;
-                pitch = 0f;
-            }
-            else
-            {
-                float sqx = q.X * q.X;
-                float sqy = q.Y * q.Y;
-                float sqz = q.Z * q.Z;
-                yaw   = (float)Math.Atan2(2 * q.Y * q.W - 2 * q.X * q.Z, 1 - 2 * sqy - 2 * sqz);
-                roll  = (float)Math.Asin(2 * test);
-                pitch = (float)Math.Atan2(2 * q.X * q.W - 2 * q.Y * q.Z, 1 - 2 * sqx - 2 * sqz);
-            }
-
-            return new Vector3(pitch, yaw, roll);
-        }
-    }
+	}
 }


### PR DESCRIPTION
Removed Rotation3 and EulerRotation3 properties to avoid singularity
issues in quaternion to euler conversion.
Added various methods to set internal rotation trough euler angles.
Euler angles are intendet as follows:
Yaw is applied first, roll second, pitch third.