### PR TITLE
Switched internalRotation to quaternions in Mesh3 and PerspectiveCamera

### DIFF
--- a/aiv-fast3d/Mesh3.cs
+++ b/aiv-fast3d/Mesh3.cs
@@ -254,17 +254,17 @@ void main(){
 
         private static Shader simpleShader3 = new Shader(simpleVertexShader3, simpleFragmentShader3, null, null, null);
 
-        private Vector3 internalRotation;
+        private Quaternion internalRotation;
 
         public Vector3 Rotation3
         {
             get
             {
-                return internalRotation;
+                return Utils.QuaternionToPitchYawRoll(internalRotation);
             }
             set
             {
-                internalRotation = value;
+                SetRotation(value);
             }
         }
 
@@ -311,8 +311,11 @@ void main(){
         {
             get
             {
-                return (Matrix3.CreateRotationY(internalRotation.Y) * Matrix3.CreateRotationZ(internalRotation.Z) * Matrix3.CreateRotationX(internalRotation.X)).ExtractRotation();
-
+                return internalRotation;
+            }
+            set
+            {
+                internalRotation = value;
             }
         }
 
@@ -509,7 +512,7 @@ void main(){
 
             scale3 = Vector3.One;
             position3 = Vector3.Zero;
-            internalRotation = Vector3.Zero;
+            internalRotation = Quaternion.Identity;
 
             Name = string.Empty;
 
@@ -555,6 +558,38 @@ void main(){
             };
         }
 
+        public void Rotate(float x, float y, float z)
+        {
+            Quaternion qX = Quaternion.FromAxisAngle(Vector3.UnitX, x);
+            Quaternion qY = Quaternion.FromAxisAngle(Vector3.UnitY, y);
+            Quaternion qZ = Quaternion.FromAxisAngle(Vector3.UnitZ, z);
+            Quaternion = qX * qZ * qY * Quaternion;
+        }
+
+        public void SetEulerRotation(Vector3 pitchYawRoll)
+        {
+
+            float degToRad = (float)Math.PI / 180f;
+            pitchYawRoll *= degToRad;
+            internalRotation = (Matrix3.CreateRotationX(pitchYawRoll.X) * Matrix3.CreateRotationZ(pitchYawRoll.Z) * Matrix3.CreateRotationY(pitchYawRoll.Y)).ExtractRotation();
+        }
+
+        public void SetEulerRotation(float pitch, float yaw, float roll)
+        {
+            float degToRad = (float)Math.PI / 180f;
+            internalRotation = (Matrix3.CreateRotationX(pitch * degToRad) * Matrix3.CreateRotationZ(roll * degToRad) * Matrix3.CreateRotationY(yaw * degToRad)).ExtractRotation();
+        }
+
+        public void SetRotation(Vector3 pitchYawRoll)
+        {
+            internalRotation = (Matrix3.CreateRotationX(pitchYawRoll.X) * Matrix3.CreateRotationZ(pitchYawRoll.Z) * Matrix3.CreateRotationY(pitchYawRoll.Y)).ExtractRotation();
+        }
+
+        public void SetRotation(float pitch, float yaw, float roll)
+        {
+            internalRotation = (Matrix3.CreateRotationX(pitch) * Matrix3.CreateRotationZ(roll) * Matrix3.CreateRotationY(yaw)).ExtractRotation();
+        }
+
         public void UpdateNormals()
         {
             if (this.vn == null)
@@ -594,7 +629,7 @@ void main(){
 #else
                 Matrix4.Scale(this.scale3.X, this.scale3.Y, this.scale3.Z) *
 #endif
-                Matrix4.CreateRotationY(internalRotation.Y) * Matrix4.CreateRotationZ(internalRotation.Z) * Matrix4.CreateRotationX(internalRotation.X) *
+                Matrix4.CreateFromQuaternion(Quaternion) *
                 // here we do not re-add the pivot, so translation is pivot based too
                 Matrix4.CreateTranslation(this.position3.X, this.position3.Y, this.position3.Z);
 

--- a/aiv-fast3d/PerspectiveCamera.cs
+++ b/aiv-fast3d/PerspectiveCamera.cs
@@ -28,7 +28,7 @@ namespace Aiv.Fast3D
         {
             get
             {
-                return (Matrix3.CreateRotationY(internalRotation.Y) * Matrix3.CreateRotationZ(internalRotation.Z) * Matrix3.CreateRotationX(internalRotation.X)) * Vector3.UnitZ;
+                return Quaternion * Vector3.UnitZ;
             }
         }
 
@@ -44,11 +44,11 @@ namespace Aiv.Fast3D
         {
             get
             {
-                return (Matrix3.CreateRotationY(internalRotation.Y) * Matrix3.CreateRotationZ(internalRotation.Z) * Matrix3.CreateRotationX(internalRotation.X)) * Vector3.UnitY;
+                return Quaternion * Vector3.UnitY;
             }
         }
 
-        private Vector3 internalRotation;
+        private Quaternion internalRotation;
 
         public Vector3 EulerRotation3
         {
@@ -66,11 +66,11 @@ namespace Aiv.Fast3D
         {
             get
             {
-                return internalRotation;
+                return Utils.QuaternionToPitchYawRoll(internalRotation);
             }
             set
             {
-                internalRotation = value;
+                SetRotation(value);
             }
         }
 
@@ -78,7 +78,11 @@ namespace Aiv.Fast3D
         {
             get
             {
-                return (Matrix3.CreateRotationY(internalRotation.Y) * Matrix3.CreateRotationZ(internalRotation.Z) * Matrix3.CreateRotationX(internalRotation.X)).ExtractRotation();
+                return internalRotation;
+            }
+            set
+            {
+                internalRotation = value;
             }
         }
 
@@ -112,7 +116,7 @@ namespace Aiv.Fast3D
         public PerspectiveCamera(Vector3 position, Vector3 eulerRotation, float fov, float zNear, float zFar, float aspectRatio = 0)
         {
             this.position3 = position;
-            this.internalRotation = eulerRotation * (float)(Math.PI / 180f);
+            this.EulerRotation3 = eulerRotation;
             this.fov = fov * (float)(Math.PI / 180f);
             this.zNear = zNear;
             this.zFar = zFar;
@@ -121,6 +125,38 @@ namespace Aiv.Fast3D
             {
                 this.aspectRatio = Window.Current.aspectRatio;
             }
+        }
+
+        public void Rotate(float x, float y, float z)
+        {
+            Quaternion qX = Quaternion.FromAxisAngle(Vector3.UnitX, x);
+            Quaternion qY = Quaternion.FromAxisAngle(Vector3.UnitY, y);
+            Quaternion qZ = Quaternion.FromAxisAngle(Vector3.UnitZ, z);
+            Quaternion = qX * qZ * qY * Quaternion;
+        }
+
+        public void SetEulerRotation(Vector3 pitchYawRoll)
+        {
+
+            float degToRad = (float)Math.PI / 180f;
+            pitchYawRoll *= degToRad;
+            internalRotation = (Matrix3.CreateRotationX(pitchYawRoll.X) * Matrix3.CreateRotationZ(pitchYawRoll.Z) * Matrix3.CreateRotationY(pitchYawRoll.Y)).ExtractRotation();
+        }
+
+        public void SetEulerRotation(float pitch, float yaw, float roll)
+        {
+            float degToRad = (float)Math.PI / 180f;
+            internalRotation = (Matrix3.CreateRotationX(pitch * degToRad) * Matrix3.CreateRotationZ(roll * degToRad) * Matrix3.CreateRotationY(yaw * degToRad)).ExtractRotation();
+        }
+
+        public void SetRotation(Vector3 pitchYawRoll)
+        {
+            internalRotation = (Matrix3.CreateRotationX(pitchYawRoll.X) * Matrix3.CreateRotationZ(pitchYawRoll.Z) * Matrix3.CreateRotationY(pitchYawRoll.Y)).ExtractRotation();
+        }
+
+        public void SetRotation(float pitch, float yaw, float roll)
+        {
+            internalRotation = (Matrix3.CreateRotationX(pitch) * Matrix3.CreateRotationZ(roll) * Matrix3.CreateRotationY(yaw)).ExtractRotation();
         }
 
         public override Matrix4 Matrix()

--- a/aiv-fast3d/Sphere.cs
+++ b/aiv-fast3d/Sphere.cs
@@ -12,6 +12,10 @@ namespace Aiv.Fast3D
             {
                 return this.Scale3.X * 0.5f;
             }
+            set
+            {
+                Scale3 = value * 2f * Vector3.One;
+            }
         }
 
         public Sphere(int segments = 32)

--- a/aiv-fast3d/Utils.cs
+++ b/aiv-fast3d/Utils.cs
@@ -43,5 +43,38 @@ namespace Aiv.Fast3D
         {
             return LookAt(direction, Vector3.UnitY);
         }
+
+        // from http://www.euclideanspace.com/maths/geometry/rotations/conversions/quaternionToEuler/index.htm
+        public static Vector3 QuaternionToPitchYawRoll(Quaternion q)
+        {
+            float yaw, pitch, roll;
+            float test = q.X * q.Y + q.Z * q.W;
+
+            // 90 deg roll singularity
+            if (test > 0.499f)
+            {
+                yaw = 2f * (float)Math.Atan2(q.X, q.W);
+                roll = MathHelper.PiOver2;
+                pitch = 0f;
+            }
+            // -90 deg roll singularity
+            if (test < -0.499f)
+            {
+                yaw = -2f * (float)Math.Atan2(q.X, q.W);
+                roll = -MathHelper.PiOver2;
+                pitch = 0f;
+            }
+            else
+            {
+                float sqx = q.X * q.X;
+                float sqy = q.Y * q.Y;
+                float sqz = q.Z * q.Z;
+                yaw = (float)Math.Atan2(2 * q.Y * q.W - 2 * q.X * q.Z, 1 - 2 * sqy - 2 * sqz);
+                roll = (float)Math.Asin(2 * test);
+                pitch = (float)Math.Atan2(2 * q.X * q.W - 2 * q.Y * q.Z, 1 - 2 * sqx - 2 * sqz);
+            }
+
+            return new Vector3(pitch, yaw, roll);
+        }
     }
 }


### PR DESCRIPTION
Added Rotate(x,y,z), SetRotation and SetEulerRotation methods in Mesh3 and PerspectiveCamera classes.
Added QuaternionToPitchYawRoll method in Utils.
Added set to Sphere class Radius property.
Quaternion are better suited than EulerAngles if we want to use a physics engine, such as BEPU, or build a custom behavior engine upon this library.